### PR TITLE
Remove parent field from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>com.xiaomi</groupId>
-        <artifactId>miliao-rootpom</artifactId>
-        <version>2.0.4</version>
-    </parent>
     <groupId>com.54chen</groupId>
 	<artifactId>akka_cluster_learn</artifactId>
 	<version>0.0.1-SNAPSHOT</version>


### PR DESCRIPTION
While importing this maven project to Eclipse, it throws lots of error messages to say parent not found. When I had removed parent field from pom.xml, everything gone OK.
